### PR TITLE
Allow tuning of statuses

### DIFF
--- a/R/logwatch.R
+++ b/R/logwatch.R
@@ -6,10 +6,13 @@
 ##'   logs. Examples include "task", "installation", etc.
 ##'
 ##' @param get_status Function that will fetch a status. Accepts no
-##'   arguments, and returns one of a set of "waiting", "running" or
-##'   any status you like after that.  When status is "waiting" we
-##'   show a spinner but do not stream logs. When "running" we stream
-##'   logs (but don't show a spinner). Any other statement returns.
+##'   arguments, and returns one of a set of (by default) "waiting",
+##'   "running" or any status you like after that.  When status is
+##'   "waiting" we show a spinner but do not stream logs. When
+##'   "running" we stream logs (but don't show a spinner). Any other
+##'   statement returns.  You can change the expected "waiting" or
+##'   "running" status values with the `status_waiting` and
+##'   `status_running` arguments.
 ##'
 ##' @param get_log A callback to read logs of the installation
 ##'   (something like `function() readLines(filename, warn = FALSE)`
@@ -21,6 +24,10 @@
 ##' @param poll Time, in seconds, used to throttle calls to the status
 ##'   function. The default is 1 second
 ##'
+##' @param status_waiting The value of a waiting status
+##'
+##' @param status_running The value of a running status
+##'
 ##' @return A list with elements:
 ##'
 ##' * status: Your final status call
@@ -28,20 +35,24 @@
 ##' * end: The end time
 ##'
 ##' @export
-logwatch <- function(what, get_status, get_log, show_log = TRUE, poll = 1) {
+logwatch <- function(what, get_status, get_log, show_log = TRUE, poll = 1,
+                     status_waiting = "waiting", status_running = "running") {
   ## TODO: we should add an interrupt handler here too, and indicate
   ## if we were interrupted; let the caller decide what to do with
   ## that?
+
+  ## TODO: we should allow for skipping of some amount of log at first
+  ## TODO: we should allow for a timeout, default can be inf though
   throttled <- throttle(poll)
   t0 <- Sys.time()
   logs <- NULL
   status <- throttled(get_status())
-  if (status == "waiting") {
+  if (status == status_waiting) {
     cli::cli_progress_bar(
       format = "{cli::pb_spin} Waiting for {what} to start [{cli::pb_elapsed}]",
       format_done = paste("{.alert-success Waited {cli::pb_elapsed}",
                           "for {what} to start}"))
-    while (status == "waiting") {
+    while (status == status_waiting) {
       cli::cli_progress_update()
       status <- throttled(get_status())
     }
@@ -50,8 +61,8 @@ logwatch <- function(what, get_status, get_log, show_log = TRUE, poll = 1) {
   ## TODO: it would be nice to have a reassuring spinner here, but
   ## there's no "cleanup last print" functionality in cli at the
   ## moment (as we've used in the past) so not doing this yet.
-  if (status == "running") {
-    while (status == "running") {
+  if (status == status_running) {
+    while (status == status_running) {
       if (show_log) {
         logs <- show_new_log(get_log(), logs)
       }

--- a/R/logwatch.R
+++ b/R/logwatch.R
@@ -34,6 +34,8 @@
 ##'
 ##' @param status_timeout The value to return if we timeout
 ##'
+##' @param status_interrupt The value to return if we are interrupted
+##'
 ##' @return A list with elements:
 ##'
 ##' * status: Your final status call
@@ -43,11 +45,8 @@
 ##' @export
 logwatch <- function(what, get_status, get_log, show_log = TRUE, poll = 1,
                      timeout = Inf, status_waiting = "waiting",
-                     status_running = "running", status_timeout = "timeout") {
-  ## TODO: we should add an interrupt handler here too, and indicate
-  ## if we were interrupted; let the caller decide what to do with
-  ## that?
-
+                     status_running = "running", status_timeout = "timeout",
+                     status_interrupt = "interrupt") {
   ## TODO: we should allow for skipping of some amount of log at first
   get_status_throttled <- throttle(get_status, poll, timeout)
   t0 <- Sys.time()
@@ -83,6 +82,9 @@ logwatch <- function(what, get_status, get_log, show_log = TRUE, poll = 1,
   },
   timeout = function(e) {
     status <<- status_timeout
+  },
+  interrupt = function(e) {
+    status <<- status_interrupt
   })
 
   list(status = status, start = t0, end = Sys.time())

--- a/man/logwatch.Rd
+++ b/man/logwatch.Rd
@@ -9,6 +9,7 @@ logwatch(
   get_status,
   get_log,
   show_log = TRUE,
+  skip = 0,
   poll = 1,
   timeout = Inf,
   status_waiting = "waiting",
@@ -36,6 +37,12 @@ may be sufficient)}
 
 \item{show_log}{Logical, indicating if the installation log should
 be printed}
+
+\item{skip}{Optional integer indicating how to handle log content
+that exists at the point where we start watching. The default
+(0) shows all log contents.  A positive integer skips that many
+lines, while a negative integer shows only that many lines (so
+-5 shows the first five lines in the log).}
 
 \item{poll}{Time, in seconds, used to throttle calls to the status
 function. The default is 1 second}

--- a/man/logwatch.Rd
+++ b/man/logwatch.Rd
@@ -10,6 +10,7 @@ logwatch(
   get_log,
   show_log = TRUE,
   skip = 0,
+  show_spinner = TRUE,
   poll = 1,
   timeout = Inf,
   status_waiting = "waiting",
@@ -42,7 +43,12 @@ be printed}
 that exists at the point where we start watching. The default
 (0) shows all log contents.  A positive integer skips that many
 lines, while a negative integer shows only that many lines (so
--5 shows the first five lines in the log).}
+-5 shows the first five lines in the log).  You can pass \code{Inf}
+to discard all previous logs, but stream all new ones.}
+
+\item{show_spinner}{Logical, indicating if a spinner should be
+shown while waiting for the task to start, and if \code{show_log} is
+\code{FALSE} for the task to complete.}
 
 \item{poll}{Time, in seconds, used to throttle calls to the status
 function. The default is 1 second}

--- a/man/logwatch.Rd
+++ b/man/logwatch.Rd
@@ -4,17 +4,28 @@
 \alias{logwatch}
 \title{Watch logs}
 \usage{
-logwatch(what, get_status, get_log, show_log = TRUE, poll = 1)
+logwatch(
+  what,
+  get_status,
+  get_log,
+  show_log = TRUE,
+  poll = 1,
+  status_waiting = "waiting",
+  status_running = "running"
+)
 }
 \arguments{
 \item{what}{Very short summary of the process underlying the
 logs. Examples include "task", "installation", etc.}
 
 \item{get_status}{Function that will fetch a status. Accepts no
-arguments, and returns one of a set of "waiting", "running" or
-any status you like after that.  When status is "waiting" we
-show a spinner but do not stream logs. When "running" we stream
-logs (but don't show a spinner). Any other statement returns.}
+arguments, and returns one of a set of (by default) "waiting",
+"running" or any status you like after that.  When status is
+"waiting" we show a spinner but do not stream logs. When
+"running" we stream logs (but don't show a spinner). Any other
+statement returns.  You can change the expected "waiting" or
+"running" status values with the \code{status_waiting} and
+\code{status_running} arguments.}
 
 \item{get_log}{A callback to read logs of the installation
 (something like \code{function() readLines(filename, warn = FALSE)}
@@ -25,6 +36,10 @@ be printed}
 
 \item{poll}{Time, in seconds, used to throttle calls to the status
 function. The default is 1 second}
+
+\item{status_waiting}{The value of a waiting status}
+
+\item{status_running}{The value of a running status}
 }
 \value{
 A list with elements:

--- a/man/logwatch.Rd
+++ b/man/logwatch.Rd
@@ -10,8 +10,10 @@ logwatch(
   get_log,
   show_log = TRUE,
   poll = 1,
+  timeout = Inf,
   status_waiting = "waiting",
-  status_running = "running"
+  status_running = "running",
+  status_timeout = "timeout"
 )
 }
 \arguments{
@@ -37,9 +39,15 @@ be printed}
 \item{poll}{Time, in seconds, used to throttle calls to the status
 function. The default is 1 second}
 
+\item{timeout}{Timeout, in seconds, after which we give up. This
+does not cancel the underlying process being watched!  We return
+\code{status_timeout} after a timeout (by default "timeout").}
+
 \item{status_waiting}{The value of a waiting status}
 
 \item{status_running}{The value of a running status}
+
+\item{status_timeout}{The value to return if we timeout}
 }
 \value{
 A list with elements:

--- a/man/logwatch.Rd
+++ b/man/logwatch.Rd
@@ -13,7 +13,8 @@ logwatch(
   timeout = Inf,
   status_waiting = "waiting",
   status_running = "running",
-  status_timeout = "timeout"
+  status_timeout = "timeout",
+  status_interrupt = "interrupt"
 )
 }
 \arguments{
@@ -48,6 +49,8 @@ does not cancel the underlying process being watched!  We return
 \item{status_running}{The value of a running status}
 
 \item{status_timeout}{The value to return if we timeout}
+
+\item{status_interrupt}{The value to return if we are interrupted}
 }
 \value{
 A list with elements:

--- a/tests/testthat/test-logwatch.R
+++ b/tests/testthat/test-logwatch.R
@@ -172,3 +172,28 @@ test_that("can cope with interrupt", {
   expect_equal(res$result$status, "interrupt")
   mockery::expect_called(get_status, 4)
 })
+
+
+test_that("allow totally quiet version", {
+  mock_progress_bar <- mockery::mock()
+  mock_progress_update <- mockery::mock()
+  mock_progress_done <- mockery::mock()
+  mockery::stub(logwatch, "cli::cli_progress_bar", mock_progress_bar)
+  mockery::stub(logwatch, "cli::cli_progress_update", mock_progress_update)
+  mockery::stub(logwatch, "cli::cli_progress_done", mock_progress_done)
+
+  get_status <- mockery::mock(
+    "waiting", "waiting", "waiting", "waiting",
+    "running", "running", "running",
+    "success")
+  get_log <- mockery::mock(
+    letters[1], letters[1:2], letters[1:3], letters[1:4])
+  res <- evaluate_promise(
+    logwatch("job", get_status, get_log, show_log = FALSE,
+             show_spinner = FALSE, poll = 0))
+  expect_equal(res$messages, character())
+  expect_equal(res$output, "")
+  mockery::expect_called(mock_progress_bar, 0)
+  mockery::expect_called(mock_progress_update, 0)
+  mockery::expect_called(mock_progress_done, 0)
+})

--- a/tests/testthat/test-logwatch.R
+++ b/tests/testthat/test-logwatch.R
@@ -14,11 +14,12 @@ test_that("throttle", {
 
 
 test_that("collect logs from immediately running job", {
-  get_status <- mockery::mock("running", "running", "running", "success")
+  get_status <- mockery::mock("RUNNING", "RUNNING", "RUNNING", "SUCCESS")
   get_log <- mockery::mock(letters[1], letters[1:2], letters[1:3], letters[1:4])
   res <- evaluate_promise(
-    logwatch("job", get_status, get_log, show_log = TRUE, poll = 0))
-  expect_equal(res$result$status, "success")
+    logwatch("job", get_status, get_log, show_log = TRUE, poll = 0,
+             status_waiting = "WAITING", status_running = "RUNNING"))
+  expect_equal(res$result$status, "SUCCESS")
   expect_equal(res$messages, paste0(letters[1:4], "\n"))
   mockery::expect_called(get_status, 4)
   mockery::expect_called(get_log, 4)

--- a/tests/testthat/test-logwatch.R
+++ b/tests/testthat/test-logwatch.R
@@ -116,20 +116,37 @@ test_that("can suppress output", {
 
 
 test_that("show log differences", {
-  expect_silent(res <- show_new_log(NULL, NULL))
-  expect_null(res)
+  expect_silent(res <- show_new_log(NULL, NULL, 0))
+  expect_equal(res, character())
 
   msg <- capture_messages(
-    expect_equal(show_new_log(c("a", "b"), NULL), c("a", "b")))
+    expect_equal(show_new_log(c("a", "b"), NULL, 0), c("a", "b")))
   expect_equal(msg, c("a\nb\n"))
 
   msg <- capture_messages(
-    expect_equal(show_new_log(c("a", "b"), c("a", "b")), c("a", "b")))
+    expect_equal(show_new_log(c("a", "b"), c("a", "b"), 0), c("a", "b")))
   expect_equal(msg, character())
 
   msg <- capture_messages(
-    expect_equal(show_new_log(c("a", "b", "c"), c("a", "b")), c("a", "b", "c")))
+    expect_equal(show_new_log(c("a", "b", "c"), c("a", "b"), 0),
+                 c("a", "b", "c")))
   expect_equal(msg, "c\n")
+})
+
+
+test_that("allow skips", {
+  msg <- capture_messages(
+    expect_equal(show_new_log(letters[1:6], NULL, 4), letters[1:6]))
+  expect_equal(msg, "e\nf\n")
+  msg <- capture_messages(
+    expect_equal(show_new_log(letters[1:6], NULL, -4), letters[1:6]))
+  expect_equal(msg, "c\nd\ne\nf\n")
+  msg <- capture_messages(
+    expect_equal(show_new_log(letters[1:6], NULL, 10), letters[1:6]))
+  expect_equal(msg, character())
+  msg <- capture_messages(
+    expect_equal(show_new_log(letters[1:6], NULL, -10), letters[1:6]))
+  expect_equal(msg, "a\nb\nc\nd\ne\nf\n")
 })
 
 

--- a/tests/testthat/test-logwatch.R
+++ b/tests/testthat/test-logwatch.R
@@ -143,3 +143,15 @@ test_that("can cope with timeout", {
   expect_equal(res$output, "")
   expect_equal(res$messages, character())
 })
+
+
+test_that("can cope with interrupt", {
+  get_status <- mockery::mock(
+    "running", "running", "running",
+    signalCondition(structure(list(), class = c("interrupt", "condition"))))
+  get_log <- mockery::mock()
+  res <- testthat::evaluate_promise(
+    logwatch("job", get_status, get_log, poll = 0, show_log = FALSE))
+  expect_equal(res$result$status, "interrupt")
+  mockery::expect_called(get_status, 4)
+})


### PR DESCRIPTION
Allows us to specify the statuses we want to map to, adds support for timeout, catch interrupts and allow skipping logs. also adds a logless spinner version!